### PR TITLE
[RestApi] v0.0.6

### DIFF
--- a/rest_api/lib/src/rest_api.dart
+++ b/rest_api/lib/src/rest_api.dart
@@ -214,12 +214,21 @@ class RestApi {
       );
     }
 
-    return RestResponse(
+    final restResponse = RestResponse(
       statusCode: response.statusCode,
       body: responseBody,
       headers: headers,
     );
+
+    /// call the subclass listener
+    onResponse(restResponse);
+
+    return restResponse;
   }
+
+  /// A listener that a subclass can use to intercept responses.
+  /// [response] is always non-null.
+  void onResponse(RestResponse response) {}
 
   // subclasses can handle the thrown errors differently.
   // the default is just to throw it.

--- a/rest_api/pubspec.yaml
+++ b/rest_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rest_api
 description: A new Flutter package project.
-version: 0.0.5
+version: 0.0.6
 author:
 homepage:
 


### PR DESCRIPTION
Added the ability to intercept all responses in a subclass.

This is to facilitate custom error handling. e.g

```
onResponse(RestResponse response) {
    final customError = CustomError.fromJson(response.jsonBody.toMap());
    throw customError;
}
```