### PR TITLE
[UnfocusHandler] Explicitly request semantics

### DIFF
--- a/unfocus_handler/lib/unfocus_handler.dart
+++ b/unfocus_handler/lib/unfocus_handler.dart
@@ -4,10 +4,17 @@ import 'package:flutter/material.dart';
 
 class UnfocusHandler extends StatelessWidget {
   final Widget child;
+  final bool excludeFromSemantics;
 
   /// Wrap this around a view to automatically clear focus when the user
   /// taps outside of the text field.
-  const UnfocusHandler({@required this.child}) : assert(child != null);
+  /// To allow screen-readers to express "double tap to active" (or similar),
+  /// set `excludeFromSemantics` to `false`.
+  const UnfocusHandler({
+    @required this.child,
+    this.excludeFromSemantics = true,
+  })  : assert(child != null),
+        assert(excludeFromSemantics != null);
 
   /// Clears any focus on the page.
   static void clearFocus(BuildContext context) {
@@ -18,6 +25,7 @@ class UnfocusHandler extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       child: child,
+      excludeFromSemantics: excludeFromSemantics,
       onTap: () => clearFocus(context),
     );
   }

--- a/unfocus_handler/pubspec.yaml
+++ b/unfocus_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unfocus_handler
 description: A new Flutter package project.
-version: 0.0.2
+version: 0.0.3
 author:
 homepage:
 


### PR DESCRIPTION
Extends from #15 

The `GestureDetector` forces the `Semantics` to announce "Double tap to activate" (or similar). A boolean option has been added to disable this (or explicitly request it).