### PR TITLE
[SnackBarPresenter] Accept ScaffoldState

### DIFF
--- a/snackbar_presenter/lib/snackbar_presenter.dart
+++ b/snackbar_presenter/lib/snackbar_presenter.dart
@@ -15,7 +15,7 @@ class SnackBarPresenter {
       {Color iconColor}) {
     // If the `iconColor` is null, it will default to the icon theme data color.
     _presentSnackbar(
-      scaffoldKey,
+      scaffoldKey.currentState,
       message,
       iconColor,
       FontAwesomeIcons.infoCircle,
@@ -26,7 +26,7 @@ class SnackBarPresenter {
   static void presentSuccess(GlobalKey<ScaffoldState> scaffoldKey, String message,
       {Color iconColor}) {
     _presentSnackbar(
-      scaffoldKey,
+      scaffoldKey.currentState,
       message,
       iconColor ?? _successColor,
       FontAwesomeIcons.solidCheckCircle,
@@ -36,7 +36,7 @@ class SnackBarPresenter {
   /// Present an error [SnackBar] in the provided [Scaffold].
   static void presentError(GlobalKey<ScaffoldState> scaffoldKey, String error, {Color iconColor}) {
     _presentSnackbar(
-      scaffoldKey,
+      scaffoldKey.currentState,
       error,
       iconColor ?? _errorColor,
       FontAwesomeIcons.exclamationCircle,
@@ -45,8 +45,8 @@ class SnackBarPresenter {
 
   /// Handles displaying the action [SnackBar] with its contents.
   static void _presentSnackbar(
-      GlobalKey<ScaffoldState> scaffoldKey, String message, Color color, IconData icon) {
-    assert(scaffoldKey != null);
+      ScaffoldState scaffoldState, String message, Color color, IconData icon) {
+    assert(scaffoldState != null);
     assert(message != null);
     assert(message.isNotEmpty);
 
@@ -68,8 +68,8 @@ class SnackBarPresenter {
 
     // Hide any currently showing SnackBars. If there are none, this will do
     // nothing.
-    scaffoldKey.currentState.hideCurrentSnackBar();
+    scaffoldState.hideCurrentSnackBar();
 
-    scaffoldKey.currentState.showSnackBar(snackbar);
+    scaffoldState.showSnackBar(snackbar);
   }
 }

--- a/snackbar_presenter/lib/snackbar_presenter.dart
+++ b/snackbar_presenter/lib/snackbar_presenter.dart
@@ -11,11 +11,10 @@ class SnackBarPresenter {
   const SnackBarPresenter._();
 
   /// Present an information [SnackBar] in the provided [Scaffold].
-  static void presentInformation(GlobalKey<ScaffoldState> scaffoldKey, String message,
-      {Color iconColor}) {
+  static void presentInformation(ScaffoldState scaffoldState, String message, {Color iconColor}) {
     // If the `iconColor` is null, it will default to the icon theme data color.
     _presentSnackbar(
-      scaffoldKey.currentState,
+      scaffoldState,
       message,
       iconColor,
       FontAwesomeIcons.infoCircle,
@@ -23,10 +22,9 @@ class SnackBarPresenter {
   }
 
   /// Present a success [SnackBar] in the provided [Scaffold].
-  static void presentSuccess(GlobalKey<ScaffoldState> scaffoldKey, String message,
-      {Color iconColor}) {
+  static void presentSuccess(ScaffoldState scaffoldState, String message, {Color iconColor}) {
     _presentSnackbar(
-      scaffoldKey.currentState,
+      scaffoldState,
       message,
       iconColor ?? _successColor,
       FontAwesomeIcons.solidCheckCircle,
@@ -34,9 +32,9 @@ class SnackBarPresenter {
   }
 
   /// Present an error [SnackBar] in the provided [Scaffold].
-  static void presentError(GlobalKey<ScaffoldState> scaffoldKey, String error, {Color iconColor}) {
+  static void presentError(ScaffoldState scaffoldState, String error, {Color iconColor}) {
     _presentSnackbar(
-      scaffoldKey.currentState,
+      scaffoldState,
       error,
       iconColor ?? _errorColor,
       FontAwesomeIcons.exclamationCircle,

--- a/snackbar_presenter/pubspec.yaml
+++ b/snackbar_presenter/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  font_awesome_flutter: ^8.5.0
+  equatable: ^1.2.5
+  font_awesome_flutter: ^8.11.0
 
 
 dev_dependencies:

--- a/snackbar_presenter/pubspec.yaml
+++ b/snackbar_presenter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: snackbar_presenter
 description: A new Flutter package project.
-version: 0.0.1
+version: 0.0.2
 author:
 homepage:
 

--- a/snackbar_presenter/test/snackbar_presenter_test.dart
+++ b/snackbar_presenter/test/snackbar_presenter_test.dart
@@ -64,24 +64,26 @@ void main() {
   }
 
   testWidgets("Information SnackBar shows", (WidgetTester tester) async {
-    final createSnackBar = (key) =>
-        SnackBarPresenter.presentInformation(key, _informationMessage, iconColor: _customColor);
+    final createSnackBar = (GlobalKey<ScaffoldState> key) => SnackBarPresenter.presentInformation(
+        key.currentState, _informationMessage,
+        iconColor: _customColor);
     await _createAppPresentSnackBar(tester, createSnackBar);
 
     _testForSnackBarContent(_informationMessage, FontAwesomeIcons.infoCircle);
   });
 
   testWidgets("Success SnackBar shows", (WidgetTester tester) async {
-    final createSnackBar =
-        (key) => SnackBarPresenter.presentSuccess(key, _successMessage, iconColor: _customColor);
+    final createSnackBar = (GlobalKey<ScaffoldState> key) => SnackBarPresenter.presentSuccess(
+        key.currentState, _successMessage,
+        iconColor: _customColor);
     await _createAppPresentSnackBar(tester, createSnackBar);
 
     _testForSnackBarContent(_successMessage, FontAwesomeIcons.solidCheckCircle);
   });
 
   testWidgets("Error SnackBar shows", (WidgetTester tester) async {
-    final createSnackBar =
-        (key) => SnackBarPresenter.presentError(key, _errorMessage, iconColor: _customColor);
+    final createSnackBar = (GlobalKey<ScaffoldState> key) =>
+        SnackBarPresenter.presentError(key.currentState, _errorMessage, iconColor: _customColor);
     await _createAppPresentSnackBar(tester, createSnackBar);
 
     _testForSnackBarContent(_errorMessage, FontAwesomeIcons.exclamationCircle);
@@ -89,11 +91,11 @@ void main() {
 
   testWidgets("Hide currently showing SnackBar", (WidgetTester tester) async {
     int tapCount = 0;
-    final buttonHandler = (key) {
+    final buttonHandler = (GlobalKey<ScaffoldState> key) {
       if (tapCount % 2 == 0) {
-        SnackBarPresenter.presentInformation(key, _informationMessage);
+        SnackBarPresenter.presentInformation(key.currentState, _informationMessage);
       } else {
-        SnackBarPresenter.presentSuccess(key, _successMessage);
+        SnackBarPresenter.presentSuccess(key.currentState, _successMessage);
       }
       tapCount++;
     };


### PR DESCRIPTION
Part of [Jira Task](https://myoxygenltd.atlassian.net/browse/SCHOL-219?atlOrigin=eyJpIjoiYjdiOWM4ZTEyZDE2NDU2Mzk2NzdjOGM0YjQ4Njk4OGQiLCJwIjoiaiJ9)

This PR looks at accepting the `ScaffoldState` instead of a `GlobalKey<ScaffoldState>`. This is because there can be occasions where the key is not available, but the state is. After all, the state is available from the key. The `ScaffoldState` is obtained from doing `Scaffold.of(context)`, so it is expected that this will be used.

I have looked at creating a separate class to accommodate either state or key, but it just makes it more complicated for developing.